### PR TITLE
Ensure sort preserves edge metadata

### DIFF
--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -10,10 +10,20 @@ from pycea.tl.sort import sort
 def tdata():
     tree1 = nx.DiGraph([("root", "B"), ("root", "C")])
     nx.set_node_attributes(tree1, {"root": 1, "B": 3, "C": 2}, "value")
+    nx.set_edge_attributes(
+        tree1, {("root", "B"): {"length": 1}, ("root", "C"): {"length": 2}}
+    )
+
     tree2 = nx.DiGraph([("root", "D"), ("root", "E")])
     nx.set_node_attributes(tree2, {"root": "1", "D": "2", "E": "3"}, "str_value")
     nx.set_node_attributes(tree2, {"root": 1, "D": 2, "E": 3}, "value")
-    tdata = td.TreeData(obs=pd.DataFrame(index=["B", "C", "D", "E"]), obst={"tree1": tree1, "tree2": tree2})
+    nx.set_edge_attributes(
+        tree2, {("root", "D"): {"length": 1}, ("root", "E"): {"length": 2}}
+    )
+    tdata = td.TreeData(
+        obs=pd.DataFrame(index=["B", "C", "D", "E"]),
+        obst={"tree1": tree1, "tree2": tree2},
+    )
     yield tdata
 
 
@@ -28,3 +38,22 @@ def test_sort(tdata):
 def test_sort_invalid(tdata):
     with pytest.raises(KeyError):
         sort(tdata, "bad")
+
+
+def test_sort_preserves_edge_metadata(tdata):
+    tree1_lengths = {
+        child: tdata.obst["tree1"]["root"][child]["length"]
+        for child in tdata.obst["tree1"].successors("root")
+    }
+    tree2_lengths = {
+        child: tdata.obst["tree2"]["root"][child]["length"]
+        for child in tdata.obst["tree2"].successors("root")
+    }
+
+    sort(tdata, "value", reverse=False)
+    sort(tdata, "str_value", tree="tree2", reverse=True)
+
+    for child, length in tree1_lengths.items():
+        assert tdata.obst["tree1"]["root"][child]["length"] == length
+    for child, length in tree2_lengths.items():
+        assert tdata.obst["tree2"]["root"][child]["length"] == length


### PR DESCRIPTION
## Summary
- keep edge attributes when reordering children in `sort`
- test that `sort` maintains edge metadata

## Testing
- `pre-commit run --files src/pycea/tl/sort.py tests/test_sort.py` *(fails: command not found)*
- `PYTHONPATH=src pytest tests/test_sort.py` *(fails: No package metadata was found for pycea-lineage)*

------
https://chatgpt.com/codex/tasks/task_e_68c09899fc3c8320957fafcca75349b3