### PR TITLE
Add tree root/leaf helpers and metadata DataFrame accessors

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -56,7 +56,11 @@
 .. autosummary::
     :toctree: generated
 
+    get.edge_df
+    get.leaves
+    get.node_df
     get.palette
+    get.root
 ```
 
 ## Datasets

--- a/docs/api.md
+++ b/docs/api.md
@@ -56,11 +56,11 @@
 .. autosummary::
     :toctree: generated
 
-    get.edge_df
     get.leaves
-    get.node_df
-    get.palette
     get.root
+    get.node_df
+    get.edge_df
+    get.palette
 ```
 
 ## Datasets

--- a/docs/notebooks/getting-started.ipynb
+++ b/docs/notebooks/getting-started.ipynb
@@ -69,7 +69,7 @@
    "id": "93ed4b50",
    "metadata": {},
    "source": [
-    "Here `obst` contains a single lineage tree named `3435_NT_T1`, which is represented as a {class}`nx.DiGraph`."
+    "Here `obst` contains a single lineage tree named `3435_NT_T1`, which is represented as a {class}`networkx.DiGraph`."
    ]
   },
   {

--- a/src/pycea/get/__init__.py
+++ b/src/pycea/get/__init__.py
@@ -1,1 +1,6 @@
+from .df import edge_df, node_df
+from .leaves import leaves
 from .palette import palette
+from .root import root
+
+__all__ = ["edge_df", "leaves", "node_df", "palette", "root"]

--- a/src/pycea/get/df.py
+++ b/src/pycea/get/df.py
@@ -33,7 +33,7 @@ def _maybe_drop_tree_index(df: pd.DataFrame, n_trees: int) -> pd.DataFrame:
 
 def edge_df(tdata: td.TreeData, tree: str | Sequence[str] | None = None) -> pd.DataFrame:
     """
-    Return tree edge attributes as :class:`~pandas.DataFrame`.
+    Get tree edge attributes as :class:`~pandas.DataFrame`.
 
     Parameters
     ----------
@@ -54,7 +54,7 @@ def edge_df(tdata: td.TreeData, tree: str | Sequence[str] | None = None) -> pd.D
 
 def node_df(tdata: td.TreeData, tree: str | Sequence[str] | None = None) -> pd.DataFrame:
     """
-    Return tree node attributes as :class:`~pandas.DataFrame`.
+    Get tree node attributes as :class:`~pandas.DataFrame`.
 
     Parameters
     ----------

--- a/src/pycea/get/df.py
+++ b/src/pycea/get/df.py
@@ -32,10 +32,19 @@ def _maybe_drop_tree_index(df: pd.DataFrame, n_trees: int) -> pd.DataFrame:
 
 
 def edge_df(tdata: td.TreeData, tree: str | Sequence[str] | None = None) -> pd.DataFrame:
-    """Return edge-level metadata as a :class:`~pandas.DataFrame`.
+    """
+    Return tree edge attributes as :class:`~pandas.DataFrame`.
 
-    When multiple trees are selected, the returned DataFrame has a
-    ``("tree", "edge")`` index. Otherwise the index is simply ``"edge"``.
+    Parameters
+    ----------
+    tdata
+        The ``treedata.TreeData`` object.
+    tree
+        The `obst` key or keys of the trees.
+
+    Returns
+    -------
+    edge_df - DataFrame of edge attributes.
     """
     trees = get_trees(tdata, tree)
     keys = _infer_edge_keys(trees)
@@ -44,10 +53,19 @@ def edge_df(tdata: td.TreeData, tree: str | Sequence[str] | None = None) -> pd.D
 
 
 def node_df(tdata: td.TreeData, tree: str | Sequence[str] | None = None) -> pd.DataFrame:
-    """Return node-level metadata as a :class:`~pandas.DataFrame`.
+    """
+    Return tree node attributes as :class:`~pandas.DataFrame`.
 
-    When multiple trees are selected, the returned DataFrame has a
-    ``("tree", "node")`` index. Otherwise the index is simply ``"node"``.
+    Parameters
+    ----------
+    tdata
+        The ``treedata.TreeData`` object.
+    tree
+        The `obst` key or keys of the trees.
+
+    Returns
+    -------
+    node_df - DataFrame of node attributes.
     """
     trees = get_trees(tdata, tree)
     keys = _infer_node_keys(trees)

--- a/src/pycea/get/df.py
+++ b/src/pycea/get/df.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import networkx as nx
+import pandas as pd
+import treedata as td
+
+from pycea.utils import get_keyed_edge_data, get_keyed_node_data, get_trees
+
+
+def _infer_edge_keys(trees: Mapping[str, nx.DiGraph]) -> list[str]:
+    keyset: set[str] = set()
+    for t in trees.values():
+        for _, _, attrs in t.edges(data=True):
+            keyset.update(attrs.keys())
+    return sorted(keyset)
+
+
+def _infer_node_keys(trees: Mapping[str, nx.DiGraph]) -> list[str]:
+    keyset: set[str] = set()
+    for t in trees.values():
+        for _, attrs in t.nodes(data=True):
+            keyset.update(attrs.keys())
+    return sorted(keyset)
+
+
+def _maybe_drop_tree_index(df: pd.DataFrame, n_trees: int) -> pd.DataFrame:
+    if n_trees == 1 and "tree" in df.index.names:
+        return df.droplevel("tree")
+    return df
+
+
+def edge_df(tdata: td.TreeData, tree: str | Sequence[str] | None = None) -> pd.DataFrame:
+    """Return edge-level metadata as a :class:`~pandas.DataFrame`.
+
+    When multiple trees are selected, the returned DataFrame has a
+    ``("tree", "edge")`` index. Otherwise the index is simply ``"edge"``.
+    """
+    trees = get_trees(tdata, tree)
+    keys = _infer_edge_keys(trees)
+    df = get_keyed_edge_data(tdata, keys, tree=list(trees.keys()), slot="obst")
+    return _maybe_drop_tree_index(df, len(trees))
+
+
+def node_df(tdata: td.TreeData, tree: str | Sequence[str] | None = None) -> pd.DataFrame:
+    """Return node-level metadata as a :class:`~pandas.DataFrame`.
+
+    When multiple trees are selected, the returned DataFrame has a
+    ``("tree", "node")`` index. Otherwise the index is simply ``"node"``.
+    """
+    trees = get_trees(tdata, tree)
+    keys = _infer_node_keys(trees)
+    df = get_keyed_node_data(tdata, keys, tree=list(trees.keys()), slot="obst")
+    return _maybe_drop_tree_index(df, len(trees))

--- a/src/pycea/get/leaves.py
+++ b/src/pycea/get/leaves.py
@@ -9,21 +9,21 @@ from pycea.utils import get_trees
 
 
 def leaves(tdata: td.TreeData, tree: str | Sequence[str] | None = None) -> list[str] | Mapping[str, list[str]]:
-    """Get the leaf nodes of tree(s) in ``tdata`` in DFS post-order.
+    """
+    Get the leaves of tree.
 
     Parameters
     ----------
     tdata
-        The ``treedata.TreeData`` object containing tree(s).
+        The ``treedata.TreeData`` object.
     tree
         Optional tree key or sequence of keys. If ``None`` (default),
         leaves for all trees with nodes are returned.
 
     Returns
     -------
-    list[str] or Mapping[str, list[str]]
-        Ordered list of leaf nodes for a single tree, or a mapping from
-        tree key to ordered leaf list when multiple trees are requested.
+    leaves - DFS postorder list of leaves. List if a single tree is requested,
+        mapping from tree key to list of leaves if multiple trees are requested.
     """
     trees = get_trees(tdata, tree)
     leaves_map = {name: _get_leaves(t) for name, t in trees.items()}

--- a/src/pycea/get/leaves.py
+++ b/src/pycea/get/leaves.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import treedata as td
+
+from pycea.utils import get_leaves as _get_leaves
+from pycea.utils import get_trees
+
+
+def leaves(tdata: td.TreeData, tree: str | Sequence[str] | None = None) -> list[str] | Mapping[str, list[str]]:
+    """Get the leaf nodes of tree(s) in ``tdata`` in DFS post-order.
+
+    Parameters
+    ----------
+    tdata
+        The ``treedata.TreeData`` object containing tree(s).
+    tree
+        Optional tree key or sequence of keys. If ``None`` (default),
+        leaves for all trees with nodes are returned.
+
+    Returns
+    -------
+    list[str] or Mapping[str, list[str]]
+        Ordered list of leaf nodes for a single tree, or a mapping from
+        tree key to ordered leaf list when multiple trees are requested.
+    """
+    trees = get_trees(tdata, tree)
+    leaves_map = {name: _get_leaves(t) for name, t in trees.items()}
+    if len(leaves_map) == 1:
+        return next(iter(leaves_map.values()))
+    return leaves_map

--- a/src/pycea/get/palette.py
+++ b/src/pycea/get/palette.py
@@ -70,7 +70,7 @@ def palette(
     random_state: int | None = None,
 ) -> dict[Any, Any]:
     """
-    Returns a color palette for a given key.
+    Get color palette for a given key.
 
     Parameters
     ----------

--- a/src/pycea/get/root.py
+++ b/src/pycea/get/root.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import treedata as td
+
+from pycea.utils import get_root as _get_root
+from pycea.utils import get_trees
+
+
+def root(tdata: td.TreeData, tree: str | Sequence[str] | None = None) -> str | Mapping[str, str | None]:
+    """Get the root node(s) of tree(s) in ``tdata``.
+
+    Parameters
+    ----------
+    tdata
+        The ``treedata.TreeData`` object containing tree(s).
+    tree
+        Optional tree key or sequence of keys. If ``None`` (default),
+        roots for all trees with nodes are returned.
+
+    Returns
+    -------
+    str or Mapping[str, str | None]
+        Root node for a single tree, or a mapping from tree key to root
+        node when multiple trees are requested.
+    """
+    trees = get_trees(tdata, tree)
+    roots = {name: _get_root(t) for name, t in trees.items()}
+    if len(roots) == 1:
+        return next(iter(roots.values()))
+    return roots

--- a/src/pycea/get/root.py
+++ b/src/pycea/get/root.py
@@ -9,24 +9,23 @@ from pycea.utils import get_trees
 
 
 def root(tdata: td.TreeData, tree: str | Sequence[str] | None = None) -> str | Mapping[str, str | None]:
-    """Get the root node(s) of tree(s) in ``tdata``.
+    """
+    Get the root of tree.
 
     Parameters
     ----------
     tdata
-        The ``treedata.TreeData`` object containing tree(s).
+        The ``treedata.TreeData`` object.
     tree
-        Optional tree key or sequence of keys. If ``None`` (default),
-        roots for all trees with nodes are returned.
+        The `obst` key or keys of the trees.
 
     Returns
     -------
-    str or Mapping[str, str | None]
-        Root node for a single tree, or a mapping from tree key to root
-        node when multiple trees are requested.
+    root - str if a single tree is requested,
+        mapping from tree key to root node if multiple trees are requested.
     """
     trees = get_trees(tdata, tree)
     roots = {name: _get_root(t) for name, t in trees.items()}
     if len(roots) == 1:
-        return next(iter(roots.values()))
+        return next(iter(roots.values()))  # type: ignore
     return roots

--- a/tests/test_get_df.py
+++ b/tests/test_get_df.py
@@ -1,0 +1,62 @@
+import networkx as nx
+import treedata as td
+
+from pycea.get import edge_df, node_df
+
+
+def _make_tree():
+    t = nx.DiGraph()
+    t.add_edge("A", "B", weight=1, length=5)
+    t.add_edge("A", "C", weight=3)
+    t.nodes["A"].update(depth=0, label="root")
+    t.nodes["B"].update(depth=1, value=42)
+    t.nodes["C"].update(depth=1)
+    return t
+
+
+def test_edge_df_single_tree():
+    tdata = td.TreeData(obst={"t1": _make_tree()})
+    df = edge_df(tdata)
+    assert set(df.columns) == {"weight", "length"}
+    assert df.index.names == ["edge"]
+    assert ("A", "B") in df.index
+
+
+def test_edge_df_multiple_trees_and_tree_param():
+    t1 = _make_tree()
+    t2 = nx.DiGraph()
+    t2.add_edge("X", "Y", capacity=3)
+    tdata = td.TreeData(obst={"t1": t1, "t2": t2})
+
+    df = edge_df(tdata)
+    assert set(df.columns) == {"weight", "length", "capacity"}
+    assert df.index.names == ["tree", "edge"]
+    assert ("t2", ("X", "Y")) in df.index
+
+    df_t1 = edge_df(tdata, tree="t1")
+    assert df_t1.index.names == ["edge"]
+
+
+def test_node_df_single_tree():
+    tdata = td.TreeData(obst={"t1": _make_tree()})
+    df = node_df(tdata)
+    assert set(df.columns) == {"depth", "label", "value"}
+    assert df.index.names == ["node"]
+    assert df.loc["B", "depth"].item() == 1
+
+
+def test_node_df_multiple_trees_and_tree_param():
+    t1 = _make_tree()
+    t2 = nx.DiGraph()
+    t2.add_edge("X", "Y")
+    t2.nodes["X"].update(color="red")
+    t2.nodes["Y"].update(color="blue")
+    tdata = td.TreeData(obst={"t1": t1, "t2": t2})
+
+    df = node_df(tdata)
+    assert set(df.columns) == {"depth", "label", "value", "color"}
+    assert df.index.names == ["tree", "node"]
+    assert ("t2", "X") in df.index
+
+    df_t1 = node_df(tdata, tree="t1")
+    assert df_t1.index.names == ["node"]

--- a/tests/test_get_leaves.py
+++ b/tests/test_get_leaves.py
@@ -1,0 +1,28 @@
+import networkx as nx
+import treedata as td
+
+from pycea.get import leaves
+
+
+def _make_tree(edges):
+    t = nx.DiGraph()
+    t.add_edges_from(edges)
+    return t
+
+
+def test_leaves_single_tree():
+    t1 = _make_tree([("A", "B"), ("A", "C"), ("B", "D"), ("C", "E")])
+    tdata = td.TreeData(obst={"t1": t1})
+    assert leaves(tdata) == ["D", "E"]
+    assert leaves(tdata, "t1") == ["D", "E"]
+
+
+def test_leaves_multiple_trees():
+    t1 = _make_tree([("A", "B"), ("A", "C"), ("B", "D"), ("C", "E")])
+    t2 = _make_tree([("F", "G"), ("F", "H")])
+    tdata = td.TreeData(obst={"t1": t1, "t2": t2})
+    res_all = leaves(tdata)
+    assert res_all == {"t1": ["D", "E"], "t2": ["G", "H"]}
+    res_subset = leaves(tdata, ["t1", "t2"])
+    assert res_subset == {"t1": ["D", "E"], "t2": ["G", "H"]}
+    assert leaves(tdata, "t2") == ["G", "H"]

--- a/tests/test_get_root.py
+++ b/tests/test_get_root.py
@@ -1,0 +1,28 @@
+import networkx as nx
+import treedata as td
+
+from pycea.get import root
+
+
+def _make_tree(edges):
+    t = nx.DiGraph()
+    t.add_edges_from(edges)
+    return t
+
+
+def test_root_single_tree():
+    t1 = _make_tree([("A", "B"), ("A", "C"), ("B", "D"), ("C", "E")])
+    tdata = td.TreeData(obst={"t1": t1})
+    assert root(tdata) == "A"
+    assert root(tdata, "t1") == "A"
+
+
+def test_root_multiple_trees():
+    t1 = _make_tree([("A", "B"), ("A", "C"), ("B", "D"), ("C", "E")])
+    t2 = _make_tree([("F", "G"), ("F", "H")])
+    tdata = td.TreeData(obst={"t1": t1, "t2": t2})
+    res_all = root(tdata)
+    assert res_all == {"t1": "A", "t2": "F"}
+    res_subset = root(tdata, ["t1", "t2"])
+    assert res_subset == {"t1": "A", "t2": "F"}
+    assert root(tdata, "t1") == "A"


### PR DESCRIPTION
## Summary
- merge `edge_df` and `node_df` into a single module that infers all attribute keys and always reads from the `obst` slot
- drop the `tree` index level when only one tree is selected
- consolidate metadata DataFrame tests
- document new `pycea.get` helpers in the API reference

## Testing
- `pre-commit run --files docs/api.md src/pycea/get/__init__.py`
- `PYTHONPATH=src pytest tests/test_get_df.py tests/test_get_root.py tests/test_get_leaves.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0a022245883209de3c6a2a74ef4ec