### PR TITLE
Add n_extant tool and ribbon plot for extant branch counts

### DIFF
--- a/src/pycea/pl/__init__.py
+++ b/src/pycea/pl/__init__.py
@@ -1,1 +1,2 @@
 from .plot_tree import annotation, branches, nodes, tree
+from .plot_n_extant import n_extant

--- a/src/pycea/pl/plot_n_extant.py
+++ b/src/pycea/pl/plot_n_extant.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Literal, cast
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import treedata as td
+from matplotlib.axes import Axes
+
+from ._legend import _categorical_legend, _render_legends
+from ._utils import _get_categorical_colors
+
+
+def n_extant(
+    tdata: td.TreeData,
+    group_key: Sequence[str] | str | None = None,
+    *,
+    data: pd.DataFrame | None = None,
+    key: str = "n_extant",
+    time_key: str = "time",
+    n_extant_key: str = "n_extant",
+    stat: Literal["count", "fraction", "percent"] = "count",
+    order: Sequence[str] | None = None,
+    legend: bool | None = None,
+    ax: Axes | None = None,
+    legend_kwargs: dict[str, Any] | None = None,
+) -> Axes:
+    """
+    Plot extant branch counts over time.
+
+    Displays the number of extant branches for each depth bin, optionally grouped
+    by observation variables.
+
+    Parameters
+    ----------
+    tdata
+        TreeData object.
+    group_key
+        Column(s) in `data` identifying groups. Determined from `data` when `None`.
+    data
+        Extant counts to plot. Uses ``tdata.uns[key]`` if ``None``.
+    key
+        Key in ``tdata.uns`` storing extant counts when ``data`` is ``None``.
+    time_key
+        Column storing time or depth values.
+    n_extant_key
+        Column storing extant counts.
+    stat
+        Statistic to compute for the ribbons: 'count', 'fraction', or 'percent'.
+    order
+        Order of group categories in the stack.
+    legend
+        Whether to add a legend.
+    ax
+        Axes on which to draw the plot. Creates new axes when ``None``.
+    legend_kwargs
+        Additional keyword arguments for the legend.
+
+    Returns
+    -------
+    ax - Axis containing the ribbon plot.
+    """
+    df = data.copy() if data is not None else tdata.uns.get(key)
+    if df is None:
+        raise KeyError(f"{key!r} not found in tdata.uns and no data provided")
+    df = df.copy()
+
+    if group_key is None:
+        other_cols = [c for c in df.columns if c not in {time_key, n_extant_key}]
+        if len(other_cols) == 1:
+            group_key = other_cols[0]
+        elif len(other_cols) > 1:
+            group_key = other_cols
+
+    if isinstance(group_key, Sequence) and not isinstance(group_key, str):
+        df["_group"] = df[list(group_key)].astype(str).agg("_".join, axis=1)
+        legend_title = "_".join(group_key)
+    elif group_key is not None:
+        df["_group"] = df[group_key]
+        legend_title = str(group_key)
+    else:
+        df["_group"] = "_all"
+        legend_title = "_all"
+
+    pivot = df.pivot_table(
+        index=time_key, columns="_group", values=n_extant_key, aggfunc="sum", fill_value=0
+    ).sort_index()
+    if order is not None:
+        pivot = pivot[[c for c in order if c in pivot.columns]]
+    cumcount = pivot.cumsum(axis=1)
+
+    if stat != "count":
+        total = pivot.sum(axis=1)
+        if stat == "fraction":
+            cumcount = cumcount.div(total, axis=0)
+        elif stat == "percent":
+            cumcount = cumcount.div(total, axis=0) * 100
+        else:
+            raise ValueError("Invalid stat. Choose from 'count', 'fraction', or 'percent'.")
+
+    if ax is None:
+        _, ax = plt.subplots()
+    ax = cast(Axes, ax)
+
+    color_key = legend_title
+    color_map = _get_categorical_colors(tdata, color_key, df["_group"], save=False)
+    legends: list[dict[str, Any]] = []
+
+    for i, group in enumerate(cumcount.columns):
+        lower = cumcount.iloc[:, i - 1] if i > 0 else np.zeros(cumcount.shape[0])
+        upper = cumcount.iloc[:, i]
+        ax.fill_between(cumcount.index, lower, upper, color=color_map.get(group))
+
+    ax.set_xlabel(time_key)
+    ylabel = n_extant_key if stat == "count" else f"{stat} of {n_extant_key}"
+    ax.set_ylabel(ylabel)
+
+    if group_key is not None:
+        legends.append(_categorical_legend(legend_title, color_map))
+    if legend is True or (legend is None and legends):
+        _render_legends(ax, legends, anchor_x=1.01, spacing=0.02, shared_kwargs=legend_kwargs)
+    return ax

--- a/src/pycea/tl/__init__.py
+++ b/src/pycea/tl/__init__.py
@@ -2,6 +2,7 @@ from .ancestral_states import ancestral_states
 from .clades import clades
 from .distance import compare_distance, distance
 from .neighbor_distance import neighbor_distance
+from .n_extant import n_extant
 from .sort import sort
 from .tree_distance import tree_distance
 from .tree_neighbors import tree_neighbors

--- a/src/pycea/tl/n_extant.py
+++ b/src/pycea/tl/n_extant.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal, overload
+
+import numpy as np
+import pandas as pd
+import treedata as td
+
+from pycea.utils import get_keyed_node_data, get_trees
+from ._utils import _check_tree_overlap
+
+
+@overload
+
+def n_extant(
+    tdata: td.TreeData,
+    depth_key: str,
+    groupby: Sequence[str] | str | None = None,
+    bins: int | Sequence[float] = 20,
+    tree: str | Sequence[str] | None = None,
+    key_added: str = "n_extant",
+    copy: Literal[True, False] = True,
+) -> pd.DataFrame:
+    ...
+
+
+@overload
+
+def n_extant(
+    tdata: td.TreeData,
+    depth_key: str,
+    groupby: Sequence[str] | str | None = None,
+    bins: int | Sequence[float] = 20,
+    tree: str | Sequence[str] | None = None,
+    key_added: str = "n_extant",
+    copy: Literal[True, False] = False,
+) -> None:
+    ...
+
+
+def n_extant(
+    tdata: td.TreeData,
+    depth_key: str,
+    groupby: Sequence[str] | str | None = None,
+    bins: int | Sequence[float] = 20,
+    tree: str | Sequence[str] | None = None,
+    key_added: str = "n_extant",
+    copy: Literal[True, False] = False,
+) -> pd.DataFrame | None:
+    """
+    Count extant branches over time.
+
+    Computes the number of extant branches for each depth bin of the tree, optionally stratified by a `obst` grouping variable(s).
+
+    Parameters
+    ----------
+    tdata
+        TreeData object.
+    depth_key
+        Attribute of `tdata.obst[tree].nodes` storing node depth.
+    groupby
+        obst key(s) used to group counts. If None, counts across all branches.
+    bins
+        Number of histogram bins or explicit bin edges.
+    tree
+        tdata.obst key or keys of trees to use. If None, all trees are used.
+    key_added
+        Key under which to store results in `tdata.uns`.
+    copy
+        If True, return a DataFrame with extant counts.
+
+    Returns
+    -------
+    counts - DataFrame with columns `time`, `n_extant`, grouping variables, and `tree`.
+    """
+    # Validate tree keys and get trees
+    tree_keys = tree
+    _check_tree_overlap(tdata, tree_keys)
+    trees = get_trees(tdata, tree_keys)
+
+    # Determine grouping variables
+    if groupby is None:
+        groupby_names: list[str] = ["_all"]
+    elif isinstance(groupby, str):
+        groupby_names = [groupby]
+    else:
+        groupby_names = list(groupby)
+
+    results = []
+    for key, t in trees.items():
+        # Retrieve node data
+        node_keys = [depth_key] + groupby_names
+        nodes = get_keyed_node_data(tdata, keys=node_keys, tree=key)
+        nodes.index = nodes.index.droplevel("tree")
+        if groupby is None:
+            nodes["_all"] = 1
+
+        # Build time bins
+        timepoints = np.histogram_bin_edges(nodes[depth_key], bins=bins)
+
+        # Initialize counts per group
+        groups = nodes[groupby_names].drop_duplicates().itertuples(index=False, name=None)
+        group_counts = {g: np.zeros(len(timepoints)) for g in groups}
+
+        # Iterate edges
+        for u, v in t.edges:
+            birth = nodes.loc[u, depth_key] - 1e-4
+            birth_idx = np.searchsorted(timepoints, birth, side="right")
+            if len(list(t.successors(v))) == 0:
+                death_idx = len(timepoints)
+            else:
+                death = nodes.loc[v, depth_key] + 1e-4
+                death_idx = np.searchsorted(timepoints, death, side="left")
+            g = tuple(nodes.loc[u, groupby_names])
+            group_counts[g][birth_idx:death_idx] += 1
+
+        # Assemble DataFrame
+        for g, counts in group_counts.items():
+            data = {"time": timepoints, "n_extant": counts, "tree": key}
+            if groupby is not None:
+                for name, value in zip(groupby_names, g, strict=False):
+                    data[name] = value
+            result_df = pd.DataFrame(data)
+            results.append(result_df)
+
+    extant = pd.concat(results, ignore_index=True) if results else pd.DataFrame()
+    if groupby is None and "_all" in extant.columns:
+        extant = extant.drop(columns="_all")
+
+    # Store and return
+    tdata.uns[key_added] = extant
+    if copy:
+        return extant
+    return None

--- a/tests/test_n_extant.py
+++ b/tests/test_n_extant.py
@@ -1,0 +1,57 @@
+import networkx as nx
+import pandas as pd
+import pytest
+import treedata as td
+
+from pycea.tl import n_extant
+
+
+@pytest.fixture
+def tdata():
+    tree = nx.DiGraph([
+        ("root", "A"),
+        ("root", "B"),
+        ("A", "C"),
+        ("A", "D"),
+    ])
+    nx.set_node_attributes(tree, {"root": 0, "A": 1, "B": 1, "C": 2, "D": 2}, "depth")
+    nx.set_node_attributes(tree, {"root": "r", "A": "g1", "B": "g2", "C": "g1", "D": "g1"}, "clade")
+    nx.set_node_attributes(tree, {"root": "L1", "A": "L1", "B": "L1", "C": "L1", "D": "L1"}, "lineage")
+    tdata = td.TreeData(obs=pd.DataFrame(index=["B", "C", "D"]), obst={"tree": tree})
+    return tdata
+
+
+def test_n_extant_uns_and_copy(tdata):
+    counts = n_extant(tdata, "depth", bins=[0, 1, 2, 3], copy=True)
+    assert "n_extant" in tdata.uns
+    assert counts.equals(tdata.uns["n_extant"])
+    assert counts["n_extant"].tolist() == [2, 4, 3, 3]
+
+
+def test_n_extant_no_copy(tdata):
+    result = n_extant(tdata, "depth", bins=[0, 1, 2, 3], copy=False)
+    assert result is None
+    assert "n_extant" in tdata.uns
+
+
+def test_n_extant_groupby(tdata):
+    counts = n_extant(tdata, "depth", groupby="clade", bins=[0, 1, 2, 3], copy=True)
+    assert set(counts["clade"]) == {"r", "g1", "g2"}
+    r = counts[counts["clade"] == "r"]["n_extant"].tolist()
+    g1 = counts[counts["clade"] == "g1"]["n_extant"].tolist()
+    g2 = counts[counts["clade"] == "g2"]["n_extant"].tolist()
+    assert r == [2, 2, 1, 1]
+    assert g1 == [0, 2, 2, 2]
+    assert g2 == [0, 0, 0, 0]
+
+
+def test_n_extant_multi_groupby(tdata):
+    counts = n_extant(tdata, "depth", groupby=["clade", "lineage"], bins=[0, 1, 2, 3], copy=True)
+    assert set(counts["clade"]) == {"r", "g1", "g2"}
+    assert set(counts["lineage"]) == {"L1"}
+    r = counts[counts["clade"] == "r"]["n_extant"].tolist()
+    g1 = counts[counts["clade"] == "g1"]["n_extant"].tolist()
+    g2 = counts[counts["clade"] == "g2"]["n_extant"].tolist()
+    assert r == [2, 2, 1, 1]
+    assert g1 == [0, 2, 2, 2]
+    assert g2 == [0, 0, 0, 0]

--- a/tests/test_plot_n_extant.py
+++ b/tests/test_plot_n_extant.py
@@ -1,0 +1,53 @@
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+import networkx as nx
+import pandas as pd
+import pytest
+import treedata as td
+
+from pycea.tl import n_extant as tl_n_extant
+from pycea.pl import n_extant as pl_n_extant
+
+
+@pytest.fixture
+def tdata():
+    tree = nx.DiGraph([
+        ("root", "A"),
+        ("root", "B"),
+        ("A", "C"),
+        ("A", "D"),
+    ])
+    nx.set_node_attributes(tree, {"root": 0, "A": 1, "B": 1, "C": 2, "D": 2}, "depth")
+    nx.set_node_attributes(tree, {"root": "r", "A": "g1", "B": "g2", "C": "g1", "D": "g1"}, "clade")
+    tdata = td.TreeData(obs=pd.DataFrame(index=["B", "C", "D"]), obst={"tree": tree})
+    return tdata
+
+
+def test_plot_n_extant_uses_uns(tdata):
+    tl_n_extant(tdata, "depth", groupby="clade", bins=[0, 1, 2, 3], copy=False)
+    ax = pl_n_extant(tdata, legend=False)
+    assert len(ax.collections) == 3
+
+
+def test_plot_n_extant_ax_return(tdata):
+    counts = tl_n_extant(tdata, "depth", groupby="clade", bins=[0, 1, 2, 3], copy=True)
+    fig, ax = plt.subplots()
+    returned = pl_n_extant(tdata, group_key="clade", data=counts, ax=ax, legend=False)
+    assert returned is ax
+    plt.close(fig)
+
+
+def test_plot_n_extant_color_order(tdata):
+    counts = tl_n_extant(tdata, "depth", groupby="clade", bins=[0, 1, 2, 3], copy=True)
+    tdata.uns["clade_colors"] = ["green", "blue", "red"]
+    ax = pl_n_extant(tdata, group_key="clade", data=counts, order=["r", "g1", "g2"], legend=False)
+    colors = [tuple(poly.get_facecolor()[0]) for poly in ax.collections]
+    expected = [
+        mpl.colors.to_rgba("red"),
+        mpl.colors.to_rgba("green"),
+        mpl.colors.to_rgba("blue"),
+    ]
+    assert colors == expected
+    plt.close(ax.figure)


### PR DESCRIPTION
## Summary
- implement `tl.n_extant` to count extant branches over depth bins with optional grouping
- add `pl.n_extant` to plot extant-branch counts as stacked ribbons with statistic normalization and legend support
- test counting, uns storage, copy semantics, grouping, and plotting behavior

## Testing
- `pytest tests/test_plot_n_extant.py tests/test_n_extant.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1ec3c14dc832088d633f0bc7d1b1e