### PR TITLE
feat(tl): alignment-aware behavior for nodes/subset alignments

### DIFF
--- a/src/pycea/tl/tree_distance.py
+++ b/src/pycea/tl/tree_distance.py
@@ -145,9 +145,11 @@ def tree_distance(
 ) -> None | sp.sparse.csr_matrix | np.ndarray:
     r"""Computes tree distances between observations.
 
-    This function calculates distances between observations (typically tree leaves)
-    based on their positions and depths in the tree. It supports *lowest common ancestor (lca)*
-    and *path* distances.
+    This function calculates distances between observations based on their positions
+    and depths in the tree. For ``tdata.alignment == "leaves"``, this computes distances
+    between leaf nodes. For ``tdata.alignment == "nodes"`` or ``"subset"``, distances are
+    computed between all observed nodes (leaves and internal nodes in ``tdata.obs``).
+    It supports *lowest common ancestor (lca)* and *path* distances.
 
     Given two nodes :math:`i` and :math:`j` in a rooted tree, with depths
     :math:`d_i` and :math:`d_j`, and with their lowest common ancestor having
@@ -175,8 +177,8 @@ def tree_distance(
     obs
         The observations to use:
 
-        - If `None`, pairwise distance for tree leaves is stored in `tdata.obsp`.
-        - If a string, distance to all other tree leaves is `tdata.obs`.
+        - If `None`, pairwise distance for all observed nodes is stored in `tdata.obsp`.
+        - If a string, distance to all other observed nodes is stored in `tdata.obs`.
         - If a sequence, pairwise distance is stored in `tdata.obsp`.
         - If a sequence of pairs, distance between pairs is stored in `tdata.obsp`.
     metric


### PR DESCRIPTION
## Summary

- **`tree_neighbors`**: For `nodes`/`subset` alignment, computes neighbors over all observed nodes (leaves + internal) instead of only leaves. Updates `_lca_neighbors` and `_bfs_by_distance` to accept an `observed_nodes` set; adds a descendant-collection step to the LCA algorithm so descendants of the start node are correctly returned as neighbors.
- **`ancestral_states`**: For `nodes`/`subset` alignment, observed internal nodes with non-NaN/non-missing values are treated as fixed constraints and not overwritten during reconstruction. Adds `fixed_nodes` parameter to all reconstruction functions (`mean`, `mode`, `fitch_hartigan`, `sankoff`, callable).
- **`fitness`**: For `nodes`/`subset` alignment, writes fitness values to `tdata.obs` for all observed nodes (not just leaves), using `get_keyed_node_data` instead of `get_keyed_leaf_data`.
- **`tree_distance`**: Docstring update only — already alignment-aware via `get_tree_to_obs_map`.
- New/updated tests covering `nodes` alignment behavior for all three modules.

## Test plan

- [ ] Run full test suite: `conda run -n pycea python -m pytest`
- [ ] Verify existing `leaves` alignment tests still pass (no behavior change)
- [ ] Verify new `nodes` alignment tests produce correct distance/metric values

🤖 Generated with [Claude Code](https://claude.com/claude-code)